### PR TITLE
Use A button to switch in the skills menu

### DIFF
--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -3093,10 +3093,10 @@ static void ClearPageWindowTilemaps(u8 page)
         case PSS_PAGE_BATTLE_MOVES:
             if (sMonSummaryScreen->mode == PSS_MODE_SELECT_MOVE)
             {
-                if (sMonSummaryScreen->newMove != MOVE_NONE || sMonSummaryScreen->firstMoveIndex != MAX_MON_MOVES)
-                    ClearWindowTilemap(PSS_LABEL_WINDOW_MOVES_POWER_ACC);{
-					gSprites[sMonSummaryScreen->splitIconSpriteId].invisible = TRUE;
-				}
+                if (sMonSummaryScreen->newMove != MOVE_NONE || sMonSummaryScreen->firstMoveIndex != MAX_MON_MOVES) {
+                    ClearWindowTilemap(PSS_LABEL_WINDOW_MOVES_POWER_ACC);
+                    gSprites[sMonSummaryScreen->splitIconSpriteId].invisible = TRUE;
+                }
             }
             else
             {


### PR DESCRIPTION
The player can now check the EVs, IVs and stats by pressing the A button, instead of L, R and Start, in the skills menu within the summary screen.

This probably works as it was intended before the #1 issue, which has been tested not to happen again.

Additionally, the game tells the user at the top right corner which submenu (EVs, IVs, stats) will be shown once A is pressed, as it does in the other menus of the summary screen.

Bonus: a minor typo has been fixed.

