### PR TITLE
Final AI tuning

### DIFF
--- a/asm/macros/battle_ai_script.inc
+++ b/asm/macros/battle_ai_script.inc
@@ -630,6 +630,26 @@
     .4byte \ptr
     .endm
 
+    .macro if_user_has_revealed_move move:req, ptr:req
+    .byte 0x71
+    .2byte \move
+    .4byte \ptr
+    .endm
+
+	.macro if_has_non_ineffective_move_with_effect battler:req, param1:req, param2:req
+	.byte 0x72
+	.byte \battler
+	.byte \param1
+	.4byte \param2
+	.endm
+
+	.macro if_doesnt_have_non_ineffective_move_with_effect battler:req, param1:req, param2:req
+	.byte 0x73
+	.byte \battler
+	.byte \param1
+	.4byte \param2
+	.endm
+
 @ useful script macros
 	.macro get_curr_move_type
 	get_type AI_TYPE_MOVE

--- a/asm/macros/battle_ai_script.inc
+++ b/asm/macros/battle_ai_script.inc
@@ -732,11 +732,11 @@
     .endm
 	
 	.macro if_this_attack_might_be_the_last ptr:req
-    if_has_move_with_effect AI_TARGET, EFFECT_ALWAYS_HIT, AI_CV_EvasionUp_ScoreDown2
     @ Si tiene la Evasión subida, tiene una pequeña probabilidad de jugársela
     @ (7/8 a +2 o +3, 49/64 a +4 o más)
     @ (la probabilidad de jugársela en alguno de los turnos en los que se está 
     @ subiendo la Evasión hasta +6 es de aproximadamente un 49%)
+    if_has_non_ineffective_move_with_effect AI_TARGET, EFFECT_ALWAYS_HIT, .AI_skip_evasion_check_\@
     if_stat_level_less_than AI_USER, STAT_EVASION, 8, .AI_skip_evasion_check_\@
     if_random_less_than 32, \ptr
     if_stat_level_less_than AI_USER, STAT_EVASION, 10, .AI_skip_evasion_check_\@

--- a/asm/macros/battle_ai_script.inc
+++ b/asm/macros/battle_ai_script.inc
@@ -904,3 +904,9 @@
     if_holds_item AI_USER, ITEM_CHOICE_SPECS, \ptr
     if_holds_item AI_USER, ITEM_CHOICE_SCARF, \ptr
     .endm
+
+    .macro if_target_probably_cannot_repeat_last_effect param:req
+    if_next_turn_target_might_use_move_with_effect AI_LAST_EFFECT_BY_TARGET, .AI_target_might_repeat_efect_\@
+    goto \param
+    .AI_target_might_repeat_efect_\@:
+    .endm

--- a/asm/macros/battle_ai_script.inc
+++ b/asm/macros/battle_ai_script.inc
@@ -766,6 +766,7 @@
     if_status2 AI_TARGET, STATUS2_SUBSTITUTE, .AI_no_free_setup_\@
 	if_target_wont_attack_due_to_truant \ptr
     if_hp_less_than AI_USER, 100, .AI_no_free_setup_\@
+    if_has_non_ineffective_move_with_effect AI_TARGET, EFFECT_QUICK_ATTACK, .AI_no_free_setup_\@
     if_ability AI_USER, ABILITY_STURDY, \ptr
     if_holds_item AI_USER, ITEM_FOCUS_SASH, \ptr
     .AI_no_free_setup_\@:

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2979,9 +2979,10 @@ AI_CV_Foresight_End:
 
 AI_CV_Endure:
 	if_target_wont_attack_due_to_truant Score_Minus10
-	if_status  AI_USER, STATUS1_PSN_ANY | STATUS1_BURN, AI_CV_EndureUserStatused
+	if_status  AI_USER, STATUS1_PSN_ANY | STATUS1_BURN, AI_CV_Endure_UserWillFaintAfterEnduring
+	if_status3 AI_USER, STATUS3_LEECHSEED, AI_CV_Endure_UserWillFaintAfterEnduring
 	if_status2 AI_USER, STATUS2_CURSED | STATUS2_INFATUATION, AI_CV_EndureUserStatused
-	if_status3 AI_USER, STATUS3_PERISH_SONG | STATUS3_LEECHSEED | STATUS3_YAWN, AI_CV_EndureUserStatused
+	if_status3 AI_USER, STATUS3_PERISH_SONG | STATUS3_YAWN, AI_CV_EndureUserStatused
 	get_weather
 	if_equal AI_WEATHER_HAIL, AI_CV_EndureHail
 	if_equal AI_WEATHER_SANDSTORM, AI_CV_EndureSandstorm
@@ -2994,9 +2995,13 @@ AI_CV_Endure_NoWeatherDamageExpected:
 	if_doesnt_have_non_ineffective_move_with_effect AI_USER, EFFECT_FLAIL, AI_CV_Endure2
 	score +1
 	goto AI_CV_Endure_End
-	
+
 AI_CV_EndureUserStatused:
 	score -2
+	goto AI_CV_Endure4
+
+AI_CV_Endure_UserWillFaintAfterEnduring:
+	score -7
 	goto AI_CV_Endure4
 	
 AI_CV_EndureHail:
@@ -3009,7 +3014,7 @@ AI_CV_EndureHail:
     if_equal TYPE_ICE, AI_CV_Endure_NoWeatherDamageExpected
     get_user_type2
     if_equal TYPE_ICE, AI_CV_Endure_NoWeatherDamageExpected
-    goto AI_CV_Endure2
+    goto AI_CV_Endure_UserWillFaintAfterEnduring
 	
 AI_CV_EndureSandstorm:
 	get_ability AI_USER
@@ -3024,7 +3029,7 @@ AI_CV_EndureSandstorm:
 	if_equal TYPE_ROCK, AI_CV_Endure_NoWeatherDamageExpected
 	if_equal TYPE_GROUND, AI_CV_Endure_NoWeatherDamageExpected
 	if_equal TYPE_STEEL, AI_CV_Endure_NoWeatherDamageExpected
-    goto AI_CV_Endure2
+    goto AI_CV_Endure_UserWillFaintAfterEnduring
 
 AI_CV_Endure2:
 	score -3

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2637,8 +2637,13 @@ AI_CV_SleepTalk_UseToWakeUpIfNecessary:
 
 AI_CV_DestinyBond:
 	score -1
-	if_status2 AI_USER, STATUS2_SUBSTITUTE, AI_CV_DestinyBond_End
+	if_status2 AI_USER, STATUS2_SUBSTITUTE, Score_Minus2
 	if_target_faster AI_CV_DestinyBond_End
+	if_status2 AI_TARGET, STATUS2_RECHARGE, Score_Minus2
+	if_hp_less_than AI_USER, 100, AI_CV_DestinyBond_SkipSturdyOrSashCheck
+	if_ability AI_USER, ABILITY_STURDY, Score_Minus2
+	if_holds_item AI_USER, ITEM_FOCUS_SASH, Score_Minus2
+AI_CV_DestinyBond_SkipSturdyOrSashCheck:
 	if_this_attack_might_be_the_last Score_Plus2
 	if_hp_more_than AI_USER, 70, AI_CV_DestinyBond_End
 	if_random_less_than 128, AI_CV_DestinyBond2

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -1638,10 +1638,8 @@ AI_CV_AccuracyUp_End:
 
 AI_CV_EvasionUp:
     if_user_is_intoxicated_and_does_not_have_baton_pass Score_Minus5
-    if_has_move_with_effect AI_TARGET, EFFECT_ALWAYS_HIT, Score_Minus5
-    if_type AI_USER, TYPE_GHOST, AI_CV_EvasionUp_SkipVitalThrow
-    if_has_move_with_effect AI_TARGET, EFFECT_VITAL_THROW, Score_Minus5
-AI_CV_EvasionUp_SkipVitalThrow:
+    if_has_non_ineffective_move_with_effect AI_TARGET, EFFECT_ALWAYS_HIT, Score_Minus5
+    if_has_non_ineffective_move_with_effect AI_TARGET, EFFECT_VITAL_THROW, Score_Minus5
     if_ability AI_USER, ABILITY_NO_GUARD, Score_Minus5
     if_ability_might_be AI_TARGET, ABILITY_NO_GUARD, Score_Minus5
     get_weather
@@ -1851,10 +1849,8 @@ AI_CV_AccuracyDownFromChance:
 	end
 
 AI_CV_AccuracyDown: @ 82DCF0C
-    if_has_move_with_effect AI_TARGET, EFFECT_ALWAYS_HIT, Score_Minus5
-    if_type AI_USER, TYPE_GHOST, AI_CV_AccuracyDown_SkipVitalThrow
-    if_has_move_with_effect AI_TARGET, EFFECT_VITAL_THROW, Score_Minus5
-AI_CV_AccuracyDown_SkipVitalThrow:
+    if_has_non_ineffective_move_with_effect AI_TARGET, EFFECT_ALWAYS_HIT, Score_Minus5
+    if_has_non_ineffective_move_with_effect AI_TARGET, EFFECT_VITAL_THROW, Score_Minus5
     if_ability AI_USER, ABILITY_NO_GUARD, Score_Minus5
     if_ability_might_be AI_TARGET, ABILITY_NO_GUARD, Score_Minus5
 	if_user_can_probably_boost_safely Score_Plus2
@@ -2916,7 +2912,7 @@ AI_CV_Endure_NoWeatherDamageExpected:
 	if_hp_less_than AI_USER, 8, AI_CV_Endure2
 	if_hp_less_than AI_USER, 14, AI_CV_Endure4
 	if_hp_less_than AI_USER, 35, AI_CV_Endure3
-	if_doesnt_have_move_with_effect AI_USER, EFFECT_FLAIL, AI_CV_Endure2
+	if_doesnt_have_non_ineffective_move_with_effect AI_USER, EFFECT_FLAIL, AI_CV_Endure2
 	score +1
 	goto AI_CV_Endure_End
 	
@@ -2960,7 +2956,7 @@ AI_CV_Endure4:
 	goto AI_CV_Endure_End
 
 AI_CV_Endure3:
-	if_has_move_with_effect AI_USER, EFFECT_FLAIL, Score_Plus2
+	if_has_non_ineffective_move_with_effect AI_USER, EFFECT_FLAIL, Score_Plus2
 	if_random_less_than 70, AI_CV_Endure_End
 	score +1
 

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2416,11 +2416,11 @@ AI_CV_Counter:
     if_equal AI_UNKNOWN_CATEGORIES_PROBABLY_SPECIAL, Score_Minus5
     if_equal AI_ONLY_SPECIAL_KNOWN, Score_Minus5
     if_target_not_expected_to_sleep AI_CV_Counter_TargetNotSleeping
-    goto AI_CV_Counter_ScoreDown1
+    goto AI_CV_Counter_ScoreDown3
 AI_CV_Counter_TargetNotSleeping:
-	if_status AI_TARGET, STATUS1_FREEZE, AI_CV_Counter_ScoreDown1
-	if_status2 AI_TARGET, STATUS2_INFATUATION, AI_CV_Counter_ScoreDown1
-	if_status2 AI_TARGET, STATUS2_CONFUSION, AI_CV_Counter_ScoreDown1
+	if_status AI_TARGET, STATUS1_FREEZE, AI_CV_Counter_ScoreDown3
+	if_status2 AI_TARGET, STATUS2_INFATUATION, AI_CV_Counter_ScoreDown3
+	if_status2 AI_TARGET, STATUS2_CONFUSION, AI_CV_Counter_ScoreDown3
 	if_hp_more_than AI_USER, 30, AI_CV_Counter2
 	if_random_less_than 10, AI_CV_Counter2
 	score -1
@@ -2442,7 +2442,7 @@ AI_CV_Counter3:
 AI_CV_Counter4:
 	get_last_used_bank_move AI_TARGET
 	get_move_type_from_result
-	if_not_in_bytes AI_CV_Counter_PhysicalTypeList, AI_CV_Counter_ScoreDown1
+	if_not_in_bytes AI_CV_Counter_PhysicalTypeList, AI_CV_Counter_ScoreDown3
 	if_random_less_than 100, AI_CV_Counter_End
 	score +1
 	goto AI_CV_Counter_End
@@ -2455,8 +2455,8 @@ AI_CV_Counter5:
 AI_CV_Counter6:
 	end
 
-AI_CV_Counter_ScoreDown1:
-	score -1
+AI_CV_Counter_ScoreDown3:
+	score -3
 
 AI_CV_Counter_End:
 	end
@@ -3161,11 +3161,11 @@ AI_CV_MirrorCoat:
     if_equal AI_UNKNOWN_CATEGORIES_PROBABLY_PHYSICAL, Score_Minus5
     if_equal AI_ONLY_PHYSICAL_KNOWN, Score_Minus5
     if_target_not_expected_to_sleep AI_CV_MirrorCoat_TargetNotSleeping
-    goto AI_CV_MirrorCoat_ScoreDown1
+    goto AI_CV_MirrorCoat_ScoreDown3
 AI_CV_MirrorCoat_TargetNotSleeping:
-	if_status AI_TARGET, STATUS1_FREEZE, AI_CV_MirrorCoat_ScoreDown1
-	if_status2 AI_TARGET, STATUS2_INFATUATION, AI_CV_MirrorCoat_ScoreDown1
-	if_status2 AI_TARGET, STATUS2_CONFUSION, AI_CV_MirrorCoat_ScoreDown1
+	if_status AI_TARGET, STATUS1_FREEZE, AI_CV_MirrorCoat_ScoreDown3
+	if_status2 AI_TARGET, STATUS2_INFATUATION, AI_CV_MirrorCoat_ScoreDown3
+	if_status2 AI_TARGET, STATUS2_CONFUSION, AI_CV_MirrorCoat_ScoreDown3
 	if_hp_more_than AI_USER, 30, AI_CV_MirrorCoat2
 	if_random_less_than 10, AI_CV_MirrorCoat2
 	score -1
@@ -3187,7 +3187,7 @@ AI_CV_MirrorCoat3:
 AI_CV_MirrorCoat4:
 	get_last_used_bank_move AI_TARGET
 	get_move_type_from_result
-	if_not_in_bytes AI_CV_MirrorCoat_SpecialTypeList, AI_CV_MirrorCoat_ScoreDown1
+	if_not_in_bytes AI_CV_MirrorCoat_SpecialTypeList, AI_CV_MirrorCoat_ScoreDown3
 	if_random_less_than 100, AI_CV_MirrorCoat_End
 	score +1
 	goto AI_CV_MirrorCoat_End
@@ -3200,8 +3200,8 @@ AI_CV_MirrorCoat5:
 AI_CV_MirrorCoat6:
 	end
 
-AI_CV_MirrorCoat_ScoreDown1:
-	score -1
+AI_CV_MirrorCoat_ScoreDown3:
+	score -3
 
 AI_CV_MirrorCoat_End:
 	end

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2408,7 +2408,8 @@ AI_CV_Disable_End:
 	end
 
 AI_CV_Counter:
-	if_target_wont_attack_due_to_truant Score_Minus10
+    if_hp_condition USER_HAS_1_HP, Score_Minus10
+    if_target_wont_attack_due_to_truant Score_Minus10
     get_possible_categories_of_foes_attacks
     if_equal AI_SPECIAL_ONLY, Score_Minus10
     if_equal AI_NO_DAMAGING_MOVES, Score_Minus10
@@ -3128,7 +3129,8 @@ AI_CV_PsychUp_End:
 	end
 
 AI_CV_MirrorCoat:
-	if_target_wont_attack_due_to_truant Score_Minus10
+    if_hp_condition USER_HAS_1_HP, Score_Minus10
+    if_target_wont_attack_due_to_truant Score_Minus10
     get_possible_categories_of_foes_attacks
     if_equal AI_PHYSICAL_ONLY, Score_Minus10
     if_equal AI_NO_DAMAGING_MOVES, Score_Minus10

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2641,6 +2641,7 @@ AI_CV_DestinyBond:
 	if_ability AI_USER, ABILITY_STURDY, Score_Minus2
 	if_holds_item AI_USER, ITEM_FOCUS_SASH, Score_Minus2
 AI_CV_DestinyBond_SkipSturdyOrSashCheck:
+	if_status2 AI_TARGET, STATUS2_MULTIPLETURNS, AI_CV_DestinyBond_1
 	if_user_has_revealed_move MOVE_DESTINY_BOND, AI_CV_DestinyBond_MoveHasBeenRevealed
 	goto AI_CV_DestinyBond_1
 

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2325,6 +2325,7 @@ AI_CV_Substitute3:
 	score -1
 AI_CV_Substitute4:
 	if_target_faster AI_CV_Substitute_End
+	if_target_probably_cannot_repeat_last_effect AI_CV_Substitute_End
 	get_last_used_bank_move AI_TARGET
 	get_move_effect_from_result
 	if_equal EFFECT_SLEEP, AI_CV_Substitute5
@@ -2451,6 +2452,7 @@ AI_CV_Counter_MoveHasBeenRevealed:
 	get_last_used_bank_move AI_TARGET
 	get_move_effect_from_result
 	if_not_in_bytes AI_CV_ExcellentEffectsToUseAgainstCounterAndMirrorCoat, AI_CV_Counter1
+	if_target_probably_cannot_repeat_last_effect AI_CV_Counter1
 @ El rival de la IA podría boostearse hasta dar OHKO o hacerse casi intocable:
 @ conviene no usar este ataque salvo si se puede aguantar un golpe por Sturdy o sash;
 @ y aun así conviene no usarlos siempre porque el rival podría agotar los PP,
@@ -3225,6 +3227,7 @@ AI_CV_MirrorCoat_MoveHasBeenRevealed:
 	get_last_used_bank_move AI_TARGET
 	get_move_effect_from_result
 	if_not_in_bytes AI_CV_ExcellentEffectsToUseAgainstCounterAndMirrorCoat, AI_CV_MirrorCoat1
+	if_target_probably_cannot_repeat_last_effect AI_CV_MirrorCoat1
 @ El rival de la IA podría boostearse hasta dar OHKO o hacerse casi intocable:
 @ conviene no usar este ataque salvo si se puede aguantar un golpe por Sturdy o sash;
 @ y aun así conviene no usarlos siempre porque el rival podría agotar los PP,

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -2641,6 +2641,29 @@ AI_CV_DestinyBond:
 	if_ability AI_USER, ABILITY_STURDY, Score_Minus2
 	if_holds_item AI_USER, ITEM_FOCUS_SASH, Score_Minus2
 AI_CV_DestinyBond_SkipSturdyOrSashCheck:
+	if_user_has_revealed_move MOVE_DESTINY_BOND, AI_CV_DestinyBond_MoveHasBeenRevealed
+	goto AI_CV_DestinyBond_1
+
+@ El rival sabe que tenemos Destiny Bond: no hay sorpresa posible.
+@ Conviene reducir el uso de Destiny Bond para evitar fundir los PP
+@ y para evitar que el rival se aproveche de que la IA pierde el tiempo,
+@ boosteándose o metiendo Spikes por ejemplo.
+@ Para ello, una vez que la IA revela Destiny Bond,
+@ la IA tiene un 20% de no considerar usarlo cada turno si el rival usó un movimiento de daño,
+@ y un 70% de no considerar usarlo cada turno si usó uno que no es de daño o acaba de entrar.
+@ El tener un 30% de tirar Destiny Bond a partir del segundo hace que los 7 PP restantes de
+@ Destiny Bond se acaben poco antes que unos supuestos 23 PP de un ataque del oponente.
+AI_CV_DestinyBond_MoveHasBeenRevealed:
+	is_first_turn_for AI_TARGET
+	if_equal 1, AI_CV_DestinyBond_MoveHasBeenRevealed_TargetDidNotAttack
+	get_last_used_bank_move AI_TARGET
+	get_move_power_from_result
+	if_equal 0, AI_CV_DestinyBond_MoveHasBeenRevealed_TargetDidNotAttack
+	if_random_less_than 50, Score_Minus2 @ ~20% de no tirar Destiny Bond
+	goto AI_CV_DestinyBond_1
+AI_CV_DestinyBond_MoveHasBeenRevealed_TargetDidNotAttack:
+	if_random_less_than 180, Score_Minus2 @ ~70% de no tirar Destiny Bond
+AI_CV_DestinyBond_1:
 	if_this_attack_might_be_the_last Score_Plus2
 	if_hp_more_than AI_USER, 70, AI_CV_DestinyBond_End
 	if_random_less_than 128, AI_CV_DestinyBond2

--- a/include/battle.h
+++ b/include/battle.h
@@ -202,6 +202,16 @@ struct UsedMoves
     u16 unknown[MAX_MON_MOVES];
 };
 
+struct AI_MemoryStruct
+{
+    u8 lastMoveIndex:2;
+    u8 secondLastMoveIndex:2;
+    u8 opponentChanged:1;
+    u8 enoughPointsDifference:1;
+    u8 switchesDetected:1;
+    u8 triedToPredictSwitches:1;
+};
+
 struct BattleHistory
 {
     struct UsedMoves _usedMoves[2 * PARTY_SIZE];
@@ -209,6 +219,7 @@ struct BattleHistory
     u8 _itemEffects[2 * PARTY_SIZE];
     u16 trainerItems[MAX_BATTLERS_COUNT];
     u8 itemsNo;
+    struct AI_MemoryStruct switchMemory[2];
 };
 
 struct BattleScriptsStack

--- a/include/battle_ai_script_commands.h
+++ b/include/battle_ai_script_commands.h
@@ -18,6 +18,7 @@ void CopyBattlerHistoryForTransformedMon(u8 transformUser, u8 transformTarget);
 void LearnBattlerHistoryFromTransformedMon(u8 transformUser, u8 transformTarget);
 void RecordItemEffectBattle(u8 battlerId, u8 itemEffect);
 void ClearBattlerItemEffectHistory(u8 battlerId);
+void AI_MarkForcedChange(void);
 
 bool32 OurShedinjaIsVulnerable(u32 battlerAI, u32 opposingBattler, u16 consideredMove);
 bool32 IsTruantMonVulnerable(u32 battlerAI, u32 opposingBattler);

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -41,6 +41,7 @@
 #define TARGET_CANNOT_USE_SUB          2
 #define USER_CANNOT_USE_SUB            3
 #define TARGET_HAS_1_MAX_HP            4
+#define USER_HAS_1_HP                  5
 
 #define AI_NHKO_PESSIMISTIC 4
 

--- a/include/constants/battle_ai.h
+++ b/include/constants/battle_ai.h
@@ -45,6 +45,8 @@
 
 #define AI_NHKO_PESSIMISTIC 4
 
+#define AI_LAST_EFFECT_BY_TARGET 0xFF
+
 // get_possible_categories_of_foes_attacks
 #define AI_PHYSICAL_ONLY 0
 #define AI_ONLY_PHYSICAL_KNOWN 1

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -19,7 +19,6 @@
 #include "constants/items.h"
 #include "constants/moves.h"
 #include "constants/species.h"
-#include "sound.h"
 
 #include "data/probable_moves.h"
 
@@ -699,6 +698,7 @@ bool8 AICanSwitchAssumingEnoughPokemon(void)
             && !(gBattleTypeFlags & (BATTLE_TYPE_ARENA | BATTLE_TYPE_PALACE));
 }
 
+#define STORED_AI_MEMORY (BATTLE_HISTORY->switchMemory[sBattler_AI & BIT_SIDE])
 static u8 ChooseMoveOrAction_Singles(void)
 {
     u8 currentMoveArray[MAX_MON_MOVES];
@@ -706,6 +706,9 @@ static u8 ChooseMoveOrAction_Singles(void)
     u8 numOfBestMoves;
     s32 i;
 	u32 flags = AI_THINKING_STRUCT->aiFlags;
+
+    struct AI_MemoryStruct memory = STORED_AI_MEMORY;
+    ((u8*) &STORED_AI_MEMORY)[0] = 0; // se reinicia por si se decide cambiar
 
     RecordLastUsedMoveByTarget();
 
@@ -923,6 +926,138 @@ static u8 ChooseMoveOrAction_Singles(void)
                 return AI_CHOICE_SWITCH;
                }
             }
+
+        // La IA puede considerar repetir su último movimiento si observa que el rival está cambiando.
+        // Para darse cuenta de ello, se mantiene cierta información en memoria
+        if ((!memory.opponentChanged && memory.enoughPointsDifference) || gDisableStructs[sBattler_AI].isFirstTurn)
+            ((u8*) &memory)[0] = 0;
+        else if (gDisableStructs[gBattlerTarget].protectUses > 0)
+        {
+            u8 lastMoveAux = memory.lastMoveIndex;
+            memory.lastMoveIndex = memory.secondLastMoveIndex;
+            memory.secondLastMoveIndex = lastMoveAux;
+            if (!memory.switchesDetected)
+                memory.enoughPointsDifference = 0;
+        }
+        else if (!gDisableStructs[gBattlerTarget].isFirstTurn)
+            ((u8*) &memory)[0] = 0;
+        else
+        {
+            // Es posible que el oponente haya cambiado por Relevo y siendo el
+            // segundo en atacar, en cuyo caso no habría que contarlo como cambio
+            memory.opponentChanged = 1;
+            if (memory.triedToPredictSwitches)
+                memory.enoughPointsDifference = 0;
+        }
+
+        memory.triedToPredictSwitches = 0;
+
+        if (memory.opponentChanged)
+        {
+            if (AI_THINKING_STRUCT->score[chosenMovePos]
+                  - AI_THINKING_STRUCT->score[memory.lastMoveIndex]
+                  >= 6) // el nuevo movimiento supera en al menos 6 puntos el anterior
+            {
+                bool8 previous_turn_had_switches_detected = memory.switchesDetected;
+                memory.switchesDetected = memory.enoughPointsDifference && memory.secondLastMoveIndex == chosenMovePos;
+                memory.secondLastMoveIndex = memory.lastMoveIndex;
+                memory.lastMoveIndex = chosenMovePos;
+                memory.enoughPointsDifference = 1;
+
+                if (memory.switchesDetected && (Random()%2))
+                {
+                    // La IA ha detectado que el rival está cambiando y va a considerar
+                    // repetir ataque si a la IA no le conviene perder el tiempo
+                    // y el movimiento anterior puede ser ejecutado
+                    u16 previous_move = gBattleMons[sBattler_AI].moves[memory.secondLastMoveIndex];
+                    bool8 doNotRepeat = FALSE;
+
+                    // Si el rival ya no puede cambiar, no hace falta repetir
+                    // Podría descartar el cambio erróneamente en caso de Baton Pass de rival más rápido
+                    if (!IS_BATTLER_OF_TYPE(gBattlerTarget, TYPE_GHOST) &&
+                        (
+                            (gBattleMons[sBattler_AI].ability == ABILITY_SHADOW_TAG && !ABILITY_ON_OPPOSING_FIELD(sBattler_AI, ABILITY_SHADOW_TAG))
+                         || (gBattleMons[sBattler_AI].ability == ABILITY_ARENA_TRAP && !IS_BATTLER_OF_TYPE(gBattlerTarget, TYPE_FLYING) && gBattleMons[gBattlerTarget].ability != ABILITY_LEVITATE)
+                         || (gBattleMons[sBattler_AI].ability == ABILITY_MAGNET_PULL && IS_BATTLER_OF_TYPE(gBattlerTarget, TYPE_STEEL))
+                         || (gBattleMons[gBattlerTarget].status2 & (STATUS2_WRAPPED | STATUS2_ESCAPE_PREVENTION))
+                        )
+                       )
+                        doNotRepeat = TRUE;
+                    
+                    if (!doNotRepeat)
+                        switch(gBattleMoves[previous_move].target)
+                        {
+                            case MOVE_TARGET_DEPENDS:
+                            case MOVE_TARGET_USER:
+                            case MOVE_TARGET_OPPONENTS_FIELD:
+                                doNotRepeat = TRUE;
+                        }
+                    
+                    if (!doNotRepeat)
+                        switch(gBattleMoves[previous_move].effect)
+                        {
+                            case EFFECT_DISABLE:
+                            case EFFECT_ENCORE:
+                            case EFFECT_SKILL_SWAP:
+                            case EFFECT_HEAL_PULSE:
+                                doNotRepeat = TRUE;
+                        }
+
+                    if (!doNotRepeat && AI_THINKING_STRUCT->score[memory.lastMoveIndex] > 40
+                     && (
+                         (previous_turn_had_switches_detected && (Random()%5)) // tiene un 10% de jugársela si lleva más de un turno seguido aunque no pase nada de lo siguiente
+                      || (gBattleMons[sBattler_AI].status1 & (STATUS1_PSN_ANY | STATUS1_BURN))
+                      || (gBattleMons[sBattler_AI].status2 & STATUS2_CURSED)
+                      || (gStatuses3[sBattler_AI] & STATUS3_LEECHSEED)
+                      || (WEATHER_HAS_EFFECT
+                          && gBattleMons[sBattler_AI].ability != ABILITY_OVERCOAT
+                          && gBattleMons[sBattler_AI].item != ITEM_LEFTOVERS // Restos compensa el clima
+                          && !(gStatuses3[sBattler_AI] & STATUS3_ROOTED)     // Arraigo ídem
+                          && (
+                              ( // la IA pierde PS por arena
+                               (gBattleWeather & WEATHER_SANDSTORM_ANY)
+                               && !IS_BATTLER_OF_TYPE(sBattler_AI, TYPE_GROUND)
+                               && !IS_BATTLER_OF_TYPE(sBattler_AI, TYPE_ROCK)
+                               && !IS_BATTLER_OF_TYPE(sBattler_AI, TYPE_STEEL)
+                               && gBattleMons[sBattler_AI].ability != ABILITY_SAND_VEIL
+				                       && gBattleMons[sBattler_AI].ability != ABILITY_SAND_RUSH
+				                       && gBattleMons[sBattler_AI].ability != ABILITY_SAND_FORCE
+                              )
+                            ||
+                              ( // la IA pierde PS por granizo
+                               (gBattleWeather & WEATHER_HAIL_ANY)
+                               && !IS_BATTLER_OF_TYPE(sBattler_AI, TYPE_ICE)
+                               && gBattleMons[sBattler_AI].ability != ABILITY_SNOW_CLOAK
+				                       && gBattleMons[sBattler_AI].ability != ABILITY_ICE_BODY
+				                       && gBattleMons[sBattler_AI].ability != ABILITY_SLUSH_RUSH
+                              )
+                             )
+                         )
+                      || gBattleMons[sBattler_AI].pp[chosenMovePos] < 8 // la IA empieza a tener pocos PP
+                        )
+                    )
+                    {
+                        // La IA va a probar a repetir movimiento
+                        chosenMovePos = memory.secondLastMoveIndex;
+                        memory.triedToPredictSwitches = 1;
+                    }
+                }
+            }  
+            else // esto incluye que lastMoveIndex == chosenMovePos
+            {
+                memory.lastMoveIndex = chosenMovePos;
+                memory.enoughPointsDifference = 0;
+                memory.opponentChanged = 0;
+                memory.switchesDetected = 0;
+            }
+        }
+        else
+        {
+            memory.lastMoveIndex = chosenMovePos;
+            memory.switchesDetected = 0;
+        }
+
+        STORED_AI_MEMORY = memory;
         return chosenMovePos;
     }
 }
@@ -1199,6 +1334,21 @@ void RecordItemEffectBattle(u8 battlerId, u8 itemEffect)
 void ClearBattlerItemEffectHistory(u8 battlerId)
 {
     FOES_OBSERVED_ITEM_EFFECT(battlerId) = 0;
+}
+
+// La IA toma nota de que, a lo largo del turno, hubo algún cambio obligado
+// (por KO o por Roar/Whirlwind) en alguno de los equipos
+// También se usa en caso de transformación
+void AI_MarkForcedChange(void)
+{
+    s32 i;
+
+    if (!(gBattleTypeFlags & BATTLE_TYPE_DOUBLE))
+        for (i = 0; i < 2; i++)
+        {
+            BATTLE_HISTORY->switchMemory[i].opponentChanged = 0;
+            BATTLE_HISTORY->switchMemory[i].enoughPointsDifference = 1;
+        }
 }
 
 static void Cmd_if_random_less_than(void)

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -893,9 +893,7 @@ static u8 ChooseMoveOrAction_Singles(void)
         // El poke lleva muchos turnos intoxicado, mejor cambiar
         if (gBattleMons[sBattler_AI].status1 & STATUS1_TOXIC_POISON
             && ((gBattleMons[sBattler_AI].status1 & 0xF00) >> 8) >= 4 // lleva al menos 4 turnos de daño y por tanto va a perder más de un 25% (al menos un 31,25%) de sus PS
-            && ( // y no escoge un movimiento que alcance los 102 puntos (probable KO) o cure el estado
-                (currentMoveArray[0] <= 101 && move != MOVE_REST && move != MOVE_REFRESH
-                 && move != MOVE_AROMATHERAPY && move != MOVE_HEAL_BELL)
+            && (currentMoveArray[0] <= 101                            // y no escoge un movimiento que alcance los 102 puntos (probable KO)
              // Los siguientes movimientos casi nunca tiene sentido usarlos
              // estando intoxicado en un estado avanzado
              || gBattleMoves[move].effect == EFFECT_RESTORE_HP

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -3186,6 +3186,10 @@ static void Cmd_if_next_turn_target_might_use_move_with_effect(void)
 {
     s32 i;
     u8 moveLimitations = CheckMoveLimitations(gBattlerTarget, 0, MOVE_LIMITATION_CHOICE-1);
+    u8 effect = *(gAIScriptPtr + 1);
+
+    if (effect == AI_LAST_EFFECT_BY_TARGET)
+        effect = gBattleMoves[gLastMoves[gBattlerTarget]].effect;
 
     gAIScriptPtr += 6; // será sobreescrito si el objetivo sí podrá usar un movimiento con el efecto
 
@@ -3197,7 +3201,7 @@ static void Cmd_if_next_turn_target_might_use_move_with_effect(void)
 
     for (i = 0; i < MAX_MON_MOVES; i++)
     {
-        if (FOES_MOVE_HISTORY(gBattlerTarget)[i] && gBattleMoves[FOES_MOVE_HISTORY(gBattlerTarget)[i]].effect == *(gAIScriptPtr - 5))
+        if (FOES_MOVE_HISTORY(gBattlerTarget)[i] && gBattleMoves[FOES_MOVE_HISTORY(gBattlerTarget)[i]].effect == effect)
         {
             s32 j;
             for (j = 0; j < MAX_MON_MOVES; j++)

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -567,7 +567,7 @@ s32 CalculateDamageFromMove(u8 attackerId, u8 targetId, u16 move, u8 simulatedRn
     s32 damage;
 
     gCurrentMove = move;
-    CalculategBattleMoveDamageFromgCurrentMove(attackerId, targetId, simulatedRng)
+    CalculategBattleMoveDamageFromgCurrentMove(attackerId, targetId, simulatedRng);
     damage = gBattleMoveDamage;
 
     gCurrentMove = savedgCurrentMove;

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -893,7 +893,18 @@ static u8 ChooseMoveOrAction_Singles(void)
         // El poke lleva muchos turnos intoxicado, mejor cambiar
         if (gBattleMons[sBattler_AI].status1 & STATUS1_TOXIC_POISON
             && ((gBattleMons[sBattler_AI].status1 & 0xF00) >> 8) >= 4 // lleva al menos 4 turnos de daño y por tanto va a perder más de un 25% (al menos un 31,25%) de sus PS
-            && currentMoveArray[0] <= 101 // y no escoge un movimiento que alcance los 102 puntos (probable KO)
+            && ( // y no escoge un movimiento que alcance los 102 puntos (probable KO) o cure el estado
+                (currentMoveArray[0] <= 101 && move != MOVE_REST && move != MOVE_REFRESH
+                 && move != MOVE_AROMATHERAPY && move != MOVE_HEAL_BELL)
+             // Los siguientes movimientos casi nunca tiene sentido usarlos
+             // estando intoxicado en un estado avanzado
+             || gBattleMoves[move].effect == EFFECT_RESTORE_HP
+             || gBattleMoves[move].effect == EFFECT_SOFTBOILED
+             || gBattleMoves[move].effect == EFFECT_MOONLIGHT
+             || gBattleMoves[move].effect == EFFECT_MORNING_SUN
+             || gBattleMoves[move].effect == EFFECT_SYNTHESIS
+             || gBattleMoves[move].effect == EFFECT_SHORE_UP
+               )
 			&& AICanSwitchAssumingEnoughPokemon())
 			if (GetMostSuitableMonToSwitchInto_NotChangingIsUnacceptable() != PARTY_SIZE)
             {

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -3374,13 +3374,13 @@ static void Cmd_if_high_change_to_break_sub_and_keep_hitting(void)
 static void Cmd_if_user_has_revealed_move(void)
 {
     s32 i;
-    const u16 *movePtr = (u16 *)(gAIScriptPtr + 1);
+    u16 move = T1_READ_16(gAIScriptPtr + 1);
 
     for (i = 0; i < MAX_MON_MOVES; i++)
-        //if (FOES_MOVE_HISTORY(sBattler_AI)[i] == *movePtr) // esto serviría si se registrasen los ataques que va usando la IA, pero no es el caso en general
+        //if (FOES_MOVE_HISTORY(sBattler_AI)[i] == move) // esto serviría si se registrasen los ataques que va usando la IA, pero no es el caso en general
         // Lo siguiente puede fallar si el rival ha visto el movimiento de otra forma (Transform)
         // o si tiene 10 o menos PP máximos y se recuperó con Leppa Berry
-        if (gBattleMons[sBattler_AI].moves[i] == *movePtr && gBattleMons[sBattler_AI].pp[i] < CalculatePPWithBonus(*movePtr, gBattleMons[sBattler_AI].ppBonuses, i))
+        if (gBattleMons[sBattler_AI].moves[i] == move && gBattleMons[sBattler_AI].pp[i] < CalculatePPWithBonus(move, gBattleMons[sBattler_AI].ppBonuses, i))
             break;
 
     if (i == MAX_MON_MOVES)

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1135,6 +1135,7 @@ void PrepareNHKOTable(struct Pokemon *party, s32 firstId, s32 lastId, u8 filtere
         s32 i;
         struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
 		struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
+        u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
 
         for (i = firstId; i < lastId; i++)
             if (!(gBitTable[i] & filteredMons))
@@ -1142,6 +1143,7 @@ void PrepareNHKOTable(struct Pokemon *party, s32 firstId, s32 lastId, u8 filtere
                 bool8 intimidateApplies;
 
                 PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
+                gBattlerPartyIndexes[gActiveBattler] = i;
                 intimidateApplies = gBattleMons[gActiveBattler].ability == ABILITY_INTIMIDATE && VulnerableToIntimidate(opposingBattler);
                 if (intimidateApplies)
                 gBattleMons[opposingBattler].statStages[STAT_ATK] -= 1;
@@ -1172,6 +1174,7 @@ void PrepareNHKOTable(struct Pokemon *party, s32 firstId, s32 lastId, u8 filtere
         
         gBattleMons[gActiveBattler] = currentMon;
 		gDisableStructs[gActiveBattler] = disableStructCopy;
+        gBattlerPartyIndexes[gActiveBattler] = partyIndex;
     }
 }
 
@@ -1198,6 +1201,7 @@ u8 FilterSwitchInsThatMightGetKOedBeforeEndOfTurn(struct Pokemon *party, s32 fir
         u8 nhko;
         struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
         struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
+        u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
 
         for (i = firstId; i < lastId; i++)
             if (!(gBitTable[i] & filteredMons))
@@ -1205,6 +1209,7 @@ u8 FilterSwitchInsThatMightGetKOedBeforeEndOfTurn(struct Pokemon *party, s32 fir
                 bool8 intimidateApplies;
 
                 PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
+                gBattlerPartyIndexes[gActiveBattler] = i;
                 intimidateApplies = gBattleMons[gActiveBattler].ability == ABILITY_INTIMIDATE && VulnerableToIntimidate(opposingBattler);
                 if (intimidateApplies)
                     gBattleMons[opposingBattler].statStages[STAT_ATK] -= 1;
@@ -1224,6 +1229,7 @@ u8 FilterSwitchInsThatMightGetKOedBeforeEndOfTurn(struct Pokemon *party, s32 fir
 
         gBattleMons[gActiveBattler] = currentMon;
         gDisableStructs[gActiveBattler] = disableStructCopy;
+        gBattlerPartyIndexes[gActiveBattler] = partyIndex;
     }
 
     return filteredMons;
@@ -1257,6 +1263,7 @@ u8 FilterFragileMonsAgainstPriority(struct Pokemon *party, s32 firstId, s32 last
     {
         struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
         struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
+        u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
 
         for (i = firstId; i < lastId; i++)
             if (!(gBitTable[i] & filteredMons))
@@ -1264,6 +1271,7 @@ u8 FilterFragileMonsAgainstPriority(struct Pokemon *party, s32 firstId, s32 last
                 bool8 intimidateApplies;
 
                 PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
+                gBattlerPartyIndexes[gActiveBattler] = i;
                 intimidateApplies = gBattleMons[gActiveBattler].ability == ABILITY_INTIMIDATE && VulnerableToIntimidate(opposingBattler);
                 if (intimidateApplies)
                     gBattleMons[opposingBattler].statStages[STAT_ATK] -= 1;
@@ -1303,6 +1311,7 @@ u8 FilterFragileMonsAgainstPriority(struct Pokemon *party, s32 firstId, s32 last
 
         gBattleMons[gActiveBattler] = currentMon;
         gDisableStructs[gActiveBattler] = disableStructCopy;
+        gBattlerPartyIndexes[gActiveBattler] = partyIndex;
     }
 
     return filteredMons;
@@ -1361,10 +1370,12 @@ u8 FilterTruantIfUseless(struct Pokemon *party, s32 firstId, s32 lastId, u8 filt
         {
             struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
 			struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
+            u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
 			for (i = firstId; i < lastId; i++)
                 if ((gBitTable[i] & truantMons))
                 {
                     PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
+                    gBattlerPartyIndexes[gActiveBattler] = i;
 					PrepareDisableStructForSwitchIn(gActiveBattler, &disableStructCopy);
 
                     if (IsTruantMonVulnerable(gActiveBattler, opposingBattler))
@@ -1373,6 +1384,7 @@ u8 FilterTruantIfUseless(struct Pokemon *party, s32 firstId, s32 lastId, u8 filt
             
             gBattleMons[gActiveBattler] = currentMon;
 			gDisableStructs[gActiveBattler] = disableStructCopy;
+            gBattlerPartyIndexes[gActiveBattler] = partyIndex;
         }
         else // Si el rival no ha atacado, podría anticiparse aunque sea más lento
         {
@@ -1408,6 +1420,7 @@ u8 FilterShedinjaIfVulnerable(struct Pokemon *party, s32 firstId, s32 lastId, u8
     {
         struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
 		struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
+        u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
 				u16 savedCurrentMove = gCurrentMove;
 
         for (i = firstId; i < lastId; i++)
@@ -1419,6 +1432,7 @@ u8 FilterShedinjaIfVulnerable(struct Pokemon *party, s32 firstId, s32 lastId, u8
                 s32 move_i;
                 u16 move;
                 PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
+                gBattlerPartyIndexes[gActiveBattler] = i;
 				PrepareDisableStructForSwitchIn(gActiveBattler, &disableStructCopy);
 
 	if (HasYetToAttack(opposingBattler))
@@ -1436,6 +1450,7 @@ u8 FilterShedinjaIfVulnerable(struct Pokemon *party, s32 firstId, s32 lastId, u8
         gCurrentMove = savedCurrentMove;
         gBattleMons[gActiveBattler] = currentMon;
 		gDisableStructs[gActiveBattler] = disableStructCopy;
+        gBattlerPartyIndexes[gActiveBattler] = partyIndex;
     }
     return (filteredMons | vulnerableSheds);
 }
@@ -1521,8 +1536,10 @@ u8 FilterOpponentCanBeTrappedAndDefeated(struct Pokemon *party, s32 firstId, s32
                         s32 move_i;
                         struct BattlePokemon currentMon = gBattleMons[gActiveBattler];
                         struct DisableStruct disableStructCopy = gDisableStructs[gActiveBattler];
+                        u16 partyIndex = gBattlerPartyIndexes[gActiveBattler];
 
                         PokemonToBattleMon(&party[i], &gBattleMons[gActiveBattler], gCurrentMove == MOVE_BATON_PASS);
+                        gBattlerPartyIndexes[gActiveBattler] = i;
                         PrepareDisableStructForSwitchIn(gActiveBattler, &disableStructCopy);
 
                         moveLimitations = CheckMoveLimitations(gActiveBattler, 0, 0xFF);
@@ -1533,6 +1550,7 @@ u8 FilterOpponentCanBeTrappedAndDefeated(struct Pokemon *party, s32 firstId, s32
 
                         gBattleMons[gActiveBattler] = currentMon;
                         gDisableStructs[gActiveBattler] = disableStructCopy;
+                        gBattlerPartyIndexes[gActiveBattler] = partyIndex;
                     }
                     if (!canKOwithPursuit)
                         filteredMons |= gBitTable[i];

--- a/src/battle_ai_switch_items.c
+++ b/src/battle_ai_switch_items.c
@@ -1592,7 +1592,7 @@ u8 FilterKOTaking1Hit(struct Pokemon *party, s32 firstId, s32 lastId, u8 filtere
 		
 	u8 nhko_taken = nhko[i][2];
             
-            if (num_attacks_taken_until_KO > 1 || nhko_taken < 3 || (!nhko[i][3] && KnowsSomeRecoveryMove(opposingBattler)))
+            if (num_attacks_taken_until_KO > 0 && (num_attacks_taken_until_KO > 1 || nhko_taken < 3 || (!nhko[i][3] && KnowsSomeRecoveryMove(opposingBattler))))
                 filteredMons |= gBitTable[i];
         }
 
@@ -1613,7 +1613,7 @@ u8 FilterKOTaking2Hits(struct Pokemon *party, s32 firstId, s32 lastId, u8 filter
             u8 num_attacks_taken_until_KO = nhko[i][1] - nhko[i][0] + min_opponent_attacks;
             u8 nhko_taken = nhko[i][2];
             
-            if (num_attacks_taken_until_KO > 2 || nhko_taken < 5 || (!nhko[i][3] && KnowsSomeRecoveryMove(opposingBattler)))
+            if (num_attacks_taken_until_KO > 0 && ((!(num_attacks_taken_until_KO <= 1 && nhko_taken >= 3) && (num_attacks_taken_until_KO > 2 || nhko_taken < 5)) || (!nhko[i][3] && KnowsSomeRecoveryMove(opposingBattler))))
                 filteredMons |= gBitTable[i];
         }
 

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3631,6 +3631,7 @@ static void Cmd_cleareffectsonfaint(void)
         }
 
         FaintClearSetData(); // Effects like attractions, trapping, etc.
+        AI_MarkForcedChange();
         gBattlescriptCurrInstr += 2;
     }
 }
@@ -8417,6 +8418,8 @@ static void Cmd_forcerandomswitch(void)
 
             if (gBattleTypeFlags & BATTLE_TYPE_INGAME_PARTNER)
                 SwitchPartyOrderInGameMulti(gBattlerTarget, i);
+
+            AI_MarkForcedChange();
         }
     }
     else
@@ -8862,6 +8865,8 @@ static void Cmd_transformdataexecution(void)
 
 		// Si la IA se transforma en el rival, puede ver sus movimientos y habilidad
 		LearnBattlerHistoryFromTransformedMon(gBattlerAttacker, gBattlerTarget);
+
+        AI_MarkForcedChange(); // Evita que la IA tenga en cuenta sus movimientos pasados
 		
         gActiveBattler = gBattlerAttacker;
         BtlController_EmitResetActionMoveSelection(0, RESET_MOVE_SELECTION);


### PR DESCRIPTION
(Disclaimer: it might not be the final AI tuning)

This pull request encompasses many small improvements and a couple of notable enhancements for the AI. Each commit describes each addition, except the ones which add stuff that is used in other commits. While this might come a little too late, it does nevertheless make the random battles (and probably the Battle Frontier) significantly more challenging. In addition, this is expected to enhance the quality of the forthcoming droja midelar.

After importing these changes, the files `battle_main.c` and `battle_util2.c` should be recompiled, even though they are not changed, as the struct `BattleHistory` has been made larger (there was a more convenient place that also had enough unused space, but it is reset to zero each turn, so it could not be used for the intended purpose). This can be achieved by either using `touch` on them, or cleaning everything by using `make tidy`, `make mostlyclean` or `make clean` (the first one is enough, the other ones clean more than needed)